### PR TITLE
Link to 3.3.9 Understanding Docs updated

### DIFF
--- a/content/new-in-22.md
+++ b/content/new-in-22.md
@@ -401,7 +401,7 @@ Help users avoid and correct mistakes.
   <dd>A mechanism is available to assist the user in completing the cognitive function test.</dd>
 </dl>
 </blockquote>
-<p><a href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-no-exception">Understanding Accessible Authentication (No Exception)</a></p>
+<p><a href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-enhanced">Understanding Accessible Authentication (Enhanced)</a></p>
 
 ## About the Personas Quotes
 


### PR DESCRIPTION
Based on this recent change in the Understanding Docs at https://github.com/w3c/wcag/issues/3061, it appears the current link for 3.3.9 was redirecting to that of 3.3.8. This corrects that link to be the appropriate one.