### PR TITLE
Fix typo in 1.4.13 Content on Hover or Focus

### DIFF
--- a/content/new-in-21.md
+++ b/content/new-in-21.md
@@ -207,7 +207,7 @@ Make it easier for users to see and hear content including separating foreground
 <blockquote class="sc">
   <p>Where receiving and then removing pointer hover or keyboard focus triggers additional content to become visible and then hidden, the following are true:</p>
   <dl>
-    <dt>Dismissable</dt>
+    <dt>Dismissible</dt>
     <dd>A <a href="https://www.w3.org/TR/WCAG21/#dfn-mechanism" data-link-type="dfn">mechanism</a> is available to dismiss the additional content without moving pointer hover or keyboard focus, unless the additional content communicates an <a href="https://www.w3.org/TR/WCAG21/#dfn-input-error" data-link-type="dfn">input error</a> or does not obscure or replace other content;</dd>
     <dt>Hoverable</dt>
     <dd>If pointer hover can trigger the additional content, then the pointer can be moved over the additional content without the additional content disappearing;</dd>


### PR DESCRIPTION
Dismissable > Dismissible

I am pleased to report the typo seems to be _only_ in this doc.  Spelling is correct in normative text.