### PR TITLE
Update WCAG 2 at a Glance French translation + Update links to QuickRef in original version + Add Translation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Preview: https://wai-intro-wcag.netlify.com/
 
-## Translation Notes for WCAG 2.1 at a Glance
+## Translation Notes for WCAG 2 at a Glance
 
-Please consider the wording in the WCAG 2.1 success criteria. If there is a translation of WCAG 2 in your language, review it thoughtfully. This text is not the same as the success criteria wording &mdash; it is a paraphrased summary that is intended to be easier to understand and accurate - yet it does not need to be comprehensive.
+Please consider the wording in the WCAG 2.2 success criteria. If there is a translation of WCAG 2 in your language, review it thoughtfully. This text is not the same as the success criteria wording &mdash; it is a paraphrased summary that is intended to be easier to understand and accurate - yet it does not need to be comprehensive.
 
 Please collaborate with others who are familiar with WCAG to refine this wording in your language. Thank you!

--- a/content/glance.es.md
+++ b/content/glance.es.md
@@ -1,28 +1,36 @@
 ---
+# Translation instructions are after the "#" character in this first section. They are comments that do not show up in the web page. You do not need to translate the instructions after "#".
+# In this first section, do not translate the words before a colon. For example, do not translate "title:". Do translate the text after "title:".
+
 title: "WCAG 2.1 de un vistazo"
 nav_title: "De un vistazo"
-
 description: Esta página proporciona un resumen no literal de las Pautas de Accesibilidad para el Contenido Web (WCAG) 2.1.
-
 lang: es
-last_updated: 2019-07-03
-permalink: /standards-guidelines/wcag/glance/es
+last_updated: 2019-07-03  # Put the date of this translation YYYY-MM-DD (with month in the middle)
+
 translators: 
 - name: "Carlos Muncharaz"
   link: "http://www.muncharaz.eu/"
 
 github:
   repository: w3c/wai-intro-wcag
-  path: 'content/glance.es.md'
+  path: 'content/glance.es.md'  # Add the language shortcode to the middle of the filename, for example: content/index.fr.md
+
+permalink: /standards-guidelines/wcag/glance/es
+ref: /standards-guidelines/wcag/glance/ # Do not change this
 
 image: /content-images/wai-intro-wcag/general-social.jpg
 feedbackmail: wai@w3.org
+layout: default
+
+# In the footer below:
+# Do not change the dates
+# Translate the other words below, including "Date:" and "Editors:"
+# Translate the Working Group name. Leave the Working Group acronym in English.
 footer: >
   <p><strong>Fecha:</strong> Actualizado el 5 de junio del 2018. Primera publicación en julio del 2008.</p>
   <p><strong>Editores:</strong> <a href="http://www.w3.org/People/Shawn">Shawn Lawton Henry</a> y Wayne Dick.</p>
   <p>Desarrollado con la colaboración del Grupo de Trabajo de Educación y Difusión (<a href="https://www.w3.org/WAI/about/groups/eowg/">EOWG</a>) y el Grupo de Trabajo de Pautas de Accesibilidad (<a href="http://www.w3.org/WAI/GL/">AG WG</a>).</p>
-ref: /standards-guidelines/wcag/glance/
-layout: default
 
 # Read Translations Notes for this resource at https://github.com/w3c/wai-intro-wcag#readme
 ---

--- a/content/glance.fr.md
+++ b/content/glance.fr.md
@@ -1,14 +1,15 @@
 ---
-title: "WCAG 2.1 en bref"
-nav_title: "en bref"
+title: "WCAG 2 en bref"
+nav_title: "En bref"
 
-description: Cette page propose un résumé paraphrasé des règles pour l’accessibilité des contenus web (WCAG) 2.1.
+description: Cette page propose un résumé paraphrasé des règles pour l’accessibilité des contenus web (WCAG) 2.
 
 lang: fr
-last_updated: 2020-10-06
+last_updated: 2023-11-29
 permalink: /standards-guidelines/wcag/glance/fr
 translators: 
-- name: "Sylvie Duchateau"
+  - name: "Sylvie Duchateau"
+  - name: "Rémi Bétin"
 
 github:
   repository: w3c/wai-intro-wcag
@@ -17,9 +18,9 @@ github:
 image: /content-images/wai-intro-wcag/general-social.jpg
 feedbackmail: wai@w3.org
 footer: >
-  <p><strong>Date :</strong> Mis à jour le 5 juin 2018. Première publication juillet 2008.</p>
-  <p><strong>Auteurs :</strong> <a href="http://www.w3.org/People/Shawn">Shawn Lawton Henry</a> et Wayne Dick.</p>
-  <p>Développé avec la collaborationdu groupe de travail Groupe de travail Éducation et Promotion (<a href="https://www.w3.org/WAI/about/groups/eowg/">EOWG</a>) et le groupe de travail <span lang="en">Accessibility Guidelines Working Group</span> (<a href="http://www.w3.org/WAI/GL/">AG WG</a>).</p>
+  <p><strong>Date :</strong> Mis à jour le 5 octobre 2023. Première publication juillet 2008.</p>
+  <p><strong>Auteurs :</strong> <a href="https://www.w3.org/People/Shawn">Shawn Lawton Henry</a> et Wayne Dick.</p>
+  <p>Développé avec la collaborationdu groupe de travail Groupe de travail Éducation et Promotion (<a href="https://www.w3.org/WAI/about/groups/eowg/">EOWG</a>) et le groupe de travail <span lang="en">Accessibility Guidelines Working Group</span> (<a href="https://www.w3.org/WAI/GL/">AG WG</a>).</p>
 ref: /standards-guidelines/wcag/glance/
 layout: default
 
@@ -30,67 +31,74 @@ layout: default
 {% include box.html type="start" h="2" title="Résumé" class="full" %}
 {:/}
 
-Cette page propose un résumé paraphrasé des règles pour l’accessibilité des contenus web (WCAG) 2.1. Pour consulter la spécification technique normative, voir [www.w3.org/TR/WCAG21](http://www.w3.org/TR/WCAG21/).
+Cette page propose un résumé paraphrasé des règles pour l’accessibilité des contenus web (WCAG) 2.1 et 2.2.
 
 {::nomarkdown}
 {% include box.html type="end" %}
 {:/}
 
-Veuillez consulter les ressources clés suivantes pour apprendre à utiliser les WCAG 2.1 :
+Veuillez consulter les ressources clés suivantes pour en savoir plus sur les WCAG 2 :
 -   **[[Vue d’ensemble des WCAG]](/standards-guidelines/wcag/)**
--   **[Comment se conformer aux WCAG 2 (Référence rapide)](http://www.w3.org/WAI/WCAG21/quickref/)** – Une référence rapide configurable pour les exigences des règles pour l’accessibilité des contenus web (WCAG) 2 (critères de succès) et techniques
+-   **[Comment satisfaire aux WCAG 2 (référence rapide)](https://www.w3.org/WAI/WCAG22/quickref/)** – Une référence rapide configurable pour les exigences des règles pour l’accessibilité des contenus web (WCAG) 2 (critères de succès) et techniques
+-   **[[Les documents de WCAG 2]](/standards-guidelines/wcag/docs/)**
+
+Les spécifications techniques sont consultables sur [www.w3.org/TR/WCAG22 (en anglais)](https://www.w3.org/TR/WCAG22/) et [www.w3.org/Translations/WCAG21-fr](https://www.w3.org/Translations/WCAG21-fr/)
+
+## Règles
 
 {::nomarkdown}
-{% include box.html type="start" title="Perceptible" h=2 class="large" %}
+{% include box.html type="start" title="Perceptible" h=3 class="large" %}
 {:/}
 
--   Proposer des **[alternatives textuelles](http://www.w3.org/WAI/WCAG21/quickref/#text-equiv)** à tout contenu non textuel.
--   Fournir des [**sous-titres et autres alternatives**](http://www.w3.org/WAI/WCAG21/quickref/#media-equiv) pour le multimédia.
--   Créer des contenus qui peuvent être **[présentés de différentes manières](http://www.w3.org/WAI/WCAG21/quickref/#content-structure-separation)**, y compris par les technologies d’assistance, sans perdre la signification.
--   Faciliter la **[perception visuelle et auditive du contenu](http://www.w3.org/WAI/WCAG21/quickref/#visual-audio-contrast)** par l’utilisateur.
-
-{::nomarkdown}
-{% include box.html type="end" %}
-{:/}
-
-{::nomarkdown}
-{% include box.html type="start" title="Utilisable" h=2 class="large" %}
-{:/}
-
--   Rendre toutes les fonctionnalités accessibles au **[clavier](http://www.w3.org/WAI/WCAG21/quickref/#keyboard-operation)**.
--   Laisser à l’utilisateur **[suffisamment de temps](http://www.w3.org/WAI/WCAG21/quickref/#time-limits)** pour lire et utiliser le contenu.
--   Ne pas concevoir de contenu susceptible de provoquer des **[crises](http://www.w3.org/WAI/WCAG21/quickref/#seizure)** ou des réactions physiques.
--   Aider l’utilisateur à **[naviguer et trouver le contenu](http://www.w3.org/WAI/WCAG21/quickref/#navigation-mechanisms)**.
--   Faciliter l’utilisation **[d’outils de saisie autres que le clavier](https://www.w3.org/WAI/WCAG21/quickref/#navigation-mechanisms)**.
+-   Proposer des **[alternatives textuelles](https://www.w3.org/WAI/WCAG22/quickref/#text-equiv)** à tout contenu non textuel.
+-   Fournir des [**sous-titres et autres alternatives**](https://www.w3.org/WAI/WCAG22/quickref/#media-equiv) pour le multimédia.
+-   Créer des contenus qui peuvent être **[présentés de différentes manières](https://www.w3.org/WAI/WCAG22/quickref/#content-structure-separation)**, y compris par les technologies d’assistance, sans perdre la signification.
+-   Faciliter la **[perception visuelle et auditive du contenu](https://www.w3.org/WAI/WCAG22/quickref/#visual-audio-contrast)** par l’utilisateur.
 
 {::nomarkdown}
 {% include box.html type="end" %}
 {:/}
 
 {::nomarkdown}
-{% include box.html type="start" title="Compréhensible" h=2 class="large" %}
+{% include box.html type="start" title="Utilisable" h=3 class="large" %}
 {:/}
 
--   Rendre le texte **[lisible et compréhensible](http://www.w3.org/WAI/WCAG21/quickref/#meaning)**.
--   Faire en sorte que les contenus apparaissent et fonctionnent de manière **[prévisible](http://www.w3.org/WAI/WCAG21/quickref/#consistent-behavior)**.
--   Aider l’utilisateur à **[éviter et corriger les erreurs](http://www.w3.org/WAI/WCAG21/quickref/#minimize-error)**.
+-   Rendre toutes les fonctionnalités accessibles au **[clavier](https://www.w3.org/WAI/WCAG22/quickref/#keyboard-operation)**.
+-   Laisser à l’utilisateur **[suffisamment de temps](https://www.w3.org/WAI/WCAG22/quickref/#time-limits)** pour lire et utiliser le contenu.
+-   Ne pas concevoir de contenu susceptible de provoquer des **[crises](https://www.w3.org/WAI/WCAG22/quickref/#seizures-and-physical-reactions)** ou des réactions physiques.
+-   Aider l’utilisateur à **[naviguer et trouver le contenu](https://www.w3.org/WAI/WCAG22/quickref/#navigation-mechanisms)**.
+-   Faciliter l’utilisation **[d’outils de saisie autres que le clavier](https://www.w3.org/WAI/WCAG22/quickref/#input-modalities)**.
 
 {::nomarkdown}
 {% include box.html type="end" %}
 {:/}
 
 {::nomarkdown}
-{% include box.html type="start" title="Robuste" h=2 class="large" %}
+{% include box.html type="start" title="Compréhensible" h=3 class="large" %}
 {:/}
 
--   Optimiser la **[compatibilité](http://www.w3.org/WAI/WCAG21/quickref/#ensure-compat)** avec les outils des utilisateurs actuels et futurs.
+-   Rendre le texte **[lisible et compréhensible](https://www.w3.org/WAI/WCAG22/quickref/#meaning)**.
+-   Faire en sorte que les contenus apparaissent et fonctionnent de manière **[prévisible](https://www.w3.org/WAI/WCAG22/quickref/#consistent-behavior)**.
+-   Aider l’utilisateur à **[éviter et corriger les erreurs](https://www.w3.org/WAI/WCAG22/quickref/#minimize-error)**.
 
 {::nomarkdown}
 {% include box.html type="end" %}
 {:/}
 
-## Autres versions
+{::nomarkdown}
+{% include box.html type="start" title="Robuste" h=3 class="large" %}
+{:/}
 
-* [[WCAG 2.0 en bref]](/standards-guidelines/wcag/20/glance/) a deux différences par rapport au contenu ci-dessus :
-    * « Ne pas concevoir de contenu susceptible de provoquer des crises ou des réactions physiques » ne contient pas « ou des réactions physiques ».
-    * Il ne contient pas « faciliter l’utilisation d’autres outils de saisie que le clavier. »
+-   Optimiser la **[compatibilité](https://www.w3.org/WAI/WCAG22/quickref/#ensure-compat)** avec les outils des utilisateurs actuels et futurs.
+
+{::nomarkdown}
+{% include box.html type="end" %}
+{:/}
+
+## Versions
+
+Cette page inclut des résumés à l'échelle des règles. Les règles sont les mêmes dans WCAG 2.1 et WCAG 2.2. Pour en savoir plus sur les nouveaux critères de succès, consultez [[Quoi de neuf dans WCAG 2.2.]](standards-guidelines/wcag/new-in-22/).
+
+[[WCAG 2.0 en bref]](/standards-guidelines/wcag/20/glance/) a deux différences par rapport au contenu ci-dessus :
+* « Ne pas concevoir de contenu susceptible de provoquer des crises ou des réactions physiques » ne contient pas « ou des réactions physiques ».
+* Il ne contient pas « faciliter l’utilisation d’autres outils de saisie que le clavier. »

--- a/content/glance.fr.md
+++ b/content/glance.fr.md
@@ -18,8 +18,8 @@ github:
 image: /content-images/wai-intro-wcag/general-social.jpg
 feedbackmail: wai@w3.org
 footer: >
-  <p><strong>Date :</strong> Mis à jour le 5 octobre 2023. Première publication juillet 2008.</p>
-  <p><strong>Auteurs :</strong> <a href="https://www.w3.org/People/Shawn">Shawn Lawton Henry</a> et Wayne Dick.</p>
+  <p><strong>Date :</strong> Mis à jour le 29 novembre 2023. Première publication juillet 2008.</p>
+  <p><strong>Rédaction :</strong> <a href="https://www.w3.org/People/Shawn">Shawn Lawton Henry</a> et Wayne Dick.</p>
   <p>Développé avec la collaborationdu groupe de travail Groupe de travail Éducation et Promotion (<a href="https://www.w3.org/WAI/about/groups/eowg/">EOWG</a>) et le groupe de travail <span lang="en">Accessibility Guidelines Working Group</span> (<a href="https://www.w3.org/WAI/GL/">AG WG</a>).</p>
 ref: /standards-guidelines/wcag/glance/
 layout: default
@@ -31,7 +31,7 @@ layout: default
 {% include box.html type="start" h="2" title="Résumé" class="full" %}
 {:/}
 
-Cette page propose un résumé paraphrasé des règles pour l’accessibilité des contenus web (WCAG) 2.1 et 2.2.
+Cette page propose un résumé paraphrasé des Règles pour l’accessibilité des contenus Web (WCAG) 2.1 et 2.2.
 
 {::nomarkdown}
 {% include box.html type="end" %}
@@ -39,10 +39,9 @@ Cette page propose un résumé paraphrasé des règles pour l’accessibilité d
 
 Veuillez consulter les ressources clés suivantes pour en savoir plus sur les WCAG 2 :
 -   **[[Vue d’ensemble des WCAG]](/standards-guidelines/wcag/)**
--   **[Comment satisfaire aux WCAG 2 (référence rapide)](https://www.w3.org/WAI/WCAG22/quickref/)** – Une référence rapide configurable pour les exigences des règles pour l’accessibilité des contenus web (WCAG) 2 (critères de succès) et techniques
 -   **[[Les documents de WCAG 2]](/standards-guidelines/wcag/docs/)**
 
-Les spécifications techniques sont consultables sur [www.w3.org/TR/WCAG22 (en anglais)](https://www.w3.org/TR/WCAG22/) et [www.w3.org/Translations/WCAG21-fr](https://www.w3.org/Translations/WCAG21-fr/)
+Les spécifications techniques normatives sont consultables sur [www.w3.org/TR/WCAG22](https://www.w3.org/TR/WCAG22/) et [www.w3.org/TR/WCAG21](https://www.w3.org/TR/WCAG21/). Une [traduction française agréée des WCAG 2.1.](https://www.w3.org/Translations/WCAG21-fr/) est disponible.
 
 ## Règles
 
@@ -97,8 +96,8 @@ Les spécifications techniques sont consultables sur [www.w3.org/TR/WCAG22 (en a
 
 ## Versions
 
-Cette page inclut des résumés à l'échelle des règles. Les règles sont les mêmes dans WCAG 2.1 et WCAG 2.2. Pour en savoir plus sur les nouveaux critères de succès, consultez [[Quoi de neuf dans WCAG 2.2.]](standards-guidelines/wcag/new-in-22/).
+Cette page inclut des résumés à l'échelle des règles. Les règles sont les mêmes dans WCAG 2.1 et WCAG 2.2. Pour en savoir plus sur les nouveaux critères de succès, consultez [[Quoi de neuf dans WCAG 2.2.]](/standards-guidelines/wcag/new-in-22/).
 
-[[WCAG 2.0 en bref]](/standards-guidelines/wcag/20/glance/) a deux différences par rapport au contenu ci-dessus :
-* « Ne pas concevoir de contenu susceptible de provoquer des crises ou des réactions physiques » ne contient pas « ou des réactions physiques ».
-* Il ne contient pas « faciliter l’utilisation d’autres outils de saisie que le clavier. »
+[[WCAG 2.0 en bref]](/standards-guidelines/wcag/20/glance/) a deux différences par rapport au contenu ci-dessus :
+* « Ne pas concevoir de contenu susceptible de provoquer des crises ou des réactions physiques » ne contient pas « ou des réactions physiques. »
+* Il ne contient pas « faciliter l’utilisation d’autres outils de saisie que le clavier. »

--- a/content/glance.fr.md
+++ b/content/glance.fr.md
@@ -1,28 +1,36 @@
 ---
+# Translation instructions are after the "#" character in this first section. They are comments that do not show up in the web page. You do not need to translate the instructions after "#".
+# In this first section, do not translate the words before a colon. For example, do not translate "title:". Do translate the text after "title:".
+
 title: "WCAG 2 en bref"
 nav_title: "En bref"
-
 description: Cette page propose un résumé paraphrasé des règles pour l’accessibilité des contenus web (WCAG) 2.
-
 lang: fr
-last_updated: 2023-11-29
-permalink: /standards-guidelines/wcag/glance/fr
+last_updated: 2023-11-29  # Put the date of this translation YYYY-MM-DD (with month in the middle)
+
 translators: 
   - name: "Sylvie Duchateau"
   - name: "Rémi Bétin"
 
 github:
   repository: w3c/wai-intro-wcag
-  path: 'content/glance.fr.md'
+  path: 'content/glance.fr.md'  # Add the language shortcode to the middle of the filename, for example: content/index.fr.md
+
+permalink: /standards-guidelines/wcag/glance/fr
+ref: /standards-guidelines/wcag/glance/ # Do not change this
 
 image: /content-images/wai-intro-wcag/general-social.jpg
 feedbackmail: wai@w3.org
+layout: default
+
+# In the footer below:
+# Do not change the dates
+# Translate the other words below, including "Date:" and "Editors:"
+# Translate the Working Group name. Leave the Working Group acronym in English.
 footer: >
   <p><strong>Date :</strong> Mis à jour le 29 novembre 2023. Première publication juillet 2008.</p>
   <p><strong>Rédaction :</strong> <a href="https://www.w3.org/People/Shawn">Shawn Lawton Henry</a> et Wayne Dick.</p>
   <p>Développé avec la collaborationdu groupe de travail Groupe de travail Éducation et Promotion (<a href="https://www.w3.org/WAI/about/groups/eowg/">EOWG</a>) et le groupe de travail <span lang="en">Accessibility Guidelines Working Group</span> (<a href="https://www.w3.org/WAI/GL/">AG WG</a>).</p>
-ref: /standards-guidelines/wcag/glance/
-layout: default
 
 # Read Translations Notes for this resource at https://github.com/w3c/wai-intro-wcag#readme
 ---

--- a/content/glance.md
+++ b/content/glance.md
@@ -6,7 +6,7 @@ nav_title: "At a Glance"
 description: This page provides a paraphrased summary of Web Content Accessibility Guidelines (WCAG) 2.
 
 lang: en
-last_updated: 2023-10-05
+last_updated: 2023-11-29
 permalink: /standards-guidelines/wcag/glance/
 
 github:
@@ -16,9 +16,9 @@ github:
 image: /content-images/wai-intro-wcag/general-social.jpg
 feedbackmail: wai@w3.org
 footer: >
-  <p><strong>Date:</strong> Updated 5 October 2023. First published July 2008.</p>
-  <p><strong>Editors:</strong> <a href="http://www.w3.org/People/Shawn">Shawn Lawton Henry</a> and Wayne Dick.</p>
-  <p>Developed with input from the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/about/groups/eowg/">EOWG</a>) and the Accessibility Guidelines Working Group (<a href="http://www.w3.org/WAI/GL/">AG WG</a>).</p>
+  <p><strong>Date:</strong> Updated 29 November 2023. First published July 2008.</p>
+  <p><strong>Editors:</strong> <a href="https://www.w3.org/People/Shawn">Shawn Lawton Henry</a> and Wayne Dick.</p>
+  <p>Developed with input from the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/about/groups/eowg/">EOWG</a>) and the Accessibility Guidelines Working Group (<a href="https://www.w3.org/WAI/GL/">AG WG</a>).</p>
 ref: /standards-guidelines/wcag/glance/
 
 # Read Translations Notes for this resource at https://github.com/w3c/wai-intro-wcag#readme
@@ -38,7 +38,7 @@ Please see the following key resources for learning about WCAG 2:
 -   **[[WCAG Overview]](/standards-guidelines/wcag/)**
 -   **[[The WCAG 2 Documents]](/standards-guidelines/wcag/docs/)**
 
-The normative technical specifications are at [www.w3.org/TR/WCAG22](http://www.w3.org/TR/WCAG22/) and [www.w3.org/TR/WCAG21](http://www.w3.org/TR/WCAG21/)
+The normative technical specifications are at [www.w3.org/TR/WCAG22](https://www.w3.org/TR/WCAG22/) and [www.w3.org/TR/WCAG21](https://www.w3.org/TR/WCAG21/)
 
 ## Guidelines
 
@@ -46,10 +46,10 @@ The normative technical specifications are at [www.w3.org/TR/WCAG22](http://www.
 {% include box.html type="start" title="Perceivable" h=3 class="large" %}
 {:/}
 
--   Provide **[text alternatives](http://www.w3.org/WAI/WCAG21/quickref/#text-equiv)** for non-text content.
--   Provide [**captions and other alternatives**](http://www.w3.org/WAI/WCAG21/quickref/#media-equiv) for multimedia.
--   Create content that can be **[presented in different ways](http://www.w3.org/WAI/WCAG21/quickref/#content-structure-separation)**, including by assistive technologies, without losing meaning.
--   Make it easier for users to **[see and hear content](http://www.w3.org/WAI/WCAG21/quickref/#visual-audio-contrast)**.
+-   Provide **[text alternatives](https://www.w3.org/WAI/WCAG22/quickref/#text-equiv)** for non-text content.
+-   Provide [**captions and other alternatives**](https://www.w3.org/WAI/WCAG22/quickref/#media-equiv) for multimedia.
+-   Create content that can be **[presented in different ways](https://www.w3.org/WAI/WCAG22/quickref/#content-structure-separation)**, including by assistive technologies, without losing meaning.
+-   Make it easier for users to **[see and hear content](https://www.w3.org/WAI/WCAG22/quickref/#visual-audio-contrast)**.
 
 {::nomarkdown}
 {% include box.html type="end" %}
@@ -60,11 +60,11 @@ The normative technical specifications are at [www.w3.org/TR/WCAG22](http://www.
 {% include box.html type="start" title="Operable" h=3 class="large" %}
 {:/}
 
--   Make all functionality available from a **[keyboard](http://www.w3.org/WAI/WCAG21/quickref/#keyboard-operation)**.
--   Give users **[enough time](http://www.w3.org/WAI/WCAG21/quickref/#time-limits)** to read and use content.
--   Do not use content that causes **[seizures](http://www.w3.org/WAI/WCAG21/quickref/#seizures-and-physical-reactions)** or physical reactions.
--   Help users **[navigate and find content](http://www.w3.org/WAI/WCAG21/quickref/#navigation-mechanisms)**.
--   Make it easier to use **[inputs other than keyboard](https://www.w3.org/WAI/WCAG21/quickref/#input-modalities)**.
+-   Make all functionality available from a **[keyboard](https://www.w3.org/WAI/WCAG22/quickref/#keyboard-operation)**.
+-   Give users **[enough time](https://www.w3.org/WAI/WCAG22/quickref/#time-limits)** to read and use content.
+-   Do not use content that causes **[seizures](https://www.w3.org/WAI/WCAG22/quickref/#seizures-and-physical-reactions)** or physical reactions.
+-   Help users **[navigate and find content](https://www.w3.org/WAI/WCAG22/quickref/#navigation-mechanisms)**.
+-   Make it easier to use **[inputs other than keyboard](https://www.w3.org/WAI/WCAG22/quickref/#input-modalities)**.
 
 {::nomarkdown}
 {% include box.html type="end" %}
@@ -74,9 +74,9 @@ The normative technical specifications are at [www.w3.org/TR/WCAG22](http://www.
 {% include box.html type="start" title="Understandable" h=3 class="large" %}
 {:/}
 
--   Make text **[readable and understandable](http://www.w3.org/WAI/WCAG21/quickref/#meaning)**.
--   Make content appear and operate in **[predictable](http://www.w3.org/WAI/WCAG21/quickref/#consistent-behavior)** ways.
--   Help users **[avoid and correct mistakes](http://www.w3.org/WAI/WCAG21/quickref/#minimize-error)**.
+-   Make text **[readable and understandable](https://www.w3.org/WAI/WCAG22/quickref/#meaning)**.
+-   Make content appear and operate in **[predictable](https://www.w3.org/WAI/WCAG22/quickref/#consistent-behavior)** ways.
+-   Help users **[avoid and correct mistakes](https://www.w3.org/WAI/WCAG22/quickref/#minimize-error)**.
 
 {::nomarkdown}
 {% include box.html type="end" %}
@@ -86,7 +86,7 @@ The normative technical specifications are at [www.w3.org/TR/WCAG22](http://www.
 {% include box.html type="start" title="Robust" h=3 class="large" %}
 {:/}
 
--   Maximize **[compatibility](http://www.w3.org/WAI/WCAG21/quickref/#ensure-compat)** with current and future user tools.
+-   Maximize **[compatibility](https://www.w3.org/WAI/WCAG22/quickref/#ensure-compat)** with current and future user tools.
 
 {::nomarkdown}
 {% include box.html type="end" %}
@@ -94,7 +94,7 @@ The normative technical specifications are at [www.w3.org/TR/WCAG22](http://www.
 
 ## Versions
 
-This page has summaries at the guideline level. The guidelines are the same in WCAG 2.1 and WCAG 2.2. To learn about the new success criteria, see [[What's New in WCAG 2.2]](standards-guidelines/wcag/new-in-22/).
+This page has summaries at the guideline level. The guidelines are the same in WCAG 2.1 and WCAG 2.2. To learn about the new success criteria, see [[What's New in WCAG 2.2]](/standards-guidelines/wcag/new-in-22/).
 
 [[WCAG 2.0 at a Glance]](/standards-guidelines/wcag/20/glance/) has two differences from above:
 * "Do not use content that causes seizures or physical reactions." does not include "or physical reactions".

--- a/content/glance.md
+++ b/content/glance.md
@@ -1,25 +1,39 @@
 ---
+# Translation instructions are after the "#" character in this first section. They are comments that do not show up in the web page. You do not need to translate the instructions after "#".
+# In this first section, do not translate the words before a colon. For example, do not translate "title:". Do translate the text after "title:".
 
 title: "WCAG 2 at a Glance"
 nav_title: "At a Glance"
-
 description: This page provides a paraphrased summary of Web Content Accessibility Guidelines (WCAG) 2.
+lang: en  # Change "en" to the translated-language shortcode
+last_updated: 2023-11-29  # Put the date of this translation YYYY-MM-DD (with month in the middle)
 
-lang: en
-last_updated: 2023-11-29
-permalink: /standards-guidelines/wcag/glance/
+# translators: # remove from the beginning of this line and the lines below: "# " (the hash sign and the space)
+# - name: "Translator Name Here" # Add one -name: line for every translator
+# - name: "Jan Doe"   # Replace Jan Doe with translator name
+# - name: "Jan Doe"   # Replace Jan Doe with name, or delete this line if not multiple translators
+# contributors:
+# - name: "Jan Doe"   # Replace Jan Doe with contributor name, or delete this line if none
+# - name: "Jan Doe"   # Replace Jan Doe with name, or delete this line if not multiple contributors
 
 github:
   repository: w3c/wai-intro-wcag
-  path: 'content/glance.md'
+  path: 'content/glance.md' # Add the language shortcode to the middle of the filename, for example: content/index.fr.md
+
+permalink: /standards-guidelines/wcag/glance/ # Add the language shortcode to the end, with no slash at end, for example: /link/to/page/fr
+ref: /standards-guidelines/wcag/glance/ # Do not change this
 
 image: /content-images/wai-intro-wcag/general-social.jpg
 feedbackmail: wai@w3.org
+
+# In the footer below:
+# Do not change the dates
+# Translate the other words below, including "Date:" and "Editors:"
+# Translate the Working Group name. Leave the Working Group acronym in English.
 footer: >
   <p><strong>Date:</strong> Updated 29 November 2023. First published July 2008.</p>
   <p><strong>Editors:</strong> <a href="https://www.w3.org/People/Shawn">Shawn Lawton Henry</a> and Wayne Dick.</p>
   <p>Developed with input from the Education and Outreach Working Group (<a href="https://www.w3.org/WAI/about/groups/eowg/">EOWG</a>) and the Accessibility Guidelines Working Group (<a href="https://www.w3.org/WAI/GL/">AG WG</a>).</p>
-ref: /standards-guidelines/wcag/glance/
 
 # Read Translations Notes for this resource at https://github.com/w3c/wai-intro-wcag#readme
 ---


### PR DESCRIPTION
Update the original version:
– Update QuickRef links to point to WCAG 2.2. version
– Fix "What's New in WCAG 2.2." link to avoid visible brackets.
– Reorder frontmatter & add translation instructions.

Update French Translation to match new original version.

Add translation instructions in Spanish translation frontmatter.

Update resource name in README file.

Resolves https://github.com/w3c/wai-translations/issues/144